### PR TITLE
Update legacy dependencies on installer script

### DIFF
--- a/gogod/camera.py
+++ b/gogod/camera.py
@@ -4,7 +4,7 @@
 import os
 import time
 import sys
-import cv2.cv as cv
+import cv2 as cv
 from datetime import datetime
 import subprocess
 

--- a/gogod_install.sh
+++ b/gogod_install.sh
@@ -30,10 +30,10 @@ apt-get -qq update
 if [ "$(whoami)" != "root" ]; then
     SUDO=sudo
 fi
-${SUDO} apt-get -y install apt-transport-https lsb-release ca-certificates curl
+${SUDO} apt-get -qq install apt-transport-https lsb-release ca-certificates curl -y
 ${SUDO} wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
 ${SUDO} sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
-${SUDO} apt-get update
+${SUDO} apt-get -qq update
 
 echo " [step 2 of 4] installing GoGoD dependencies..."
 set -e

--- a/gogod_install.sh
+++ b/gogod_install.sh
@@ -26,6 +26,15 @@ apt-get -qq update
 #sudo apt-get install rpi-update -y
 #sudo rpi-update
 
+# add sury php repository for php 5.6
+if [ "$(whoami)" != "root" ]; then
+    SUDO=sudo
+fi
+${SUDO} apt-get -y install apt-transport-https lsb-release ca-certificates curl
+${SUDO} wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
+${SUDO} sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
+${SUDO} apt-get update
+
 echo " [step 2 of 4] installing GoGoD dependencies..."
 set -e
 # Dependencies
@@ -33,11 +42,13 @@ apt-get -qq install python-setuptools -y
 apt-get -qq install python-dev -y
 apt-get -qq install python-rpi.gpio -y
 apt-get -qq install python-pycurl -y
+apt-get -qq install libffi-dev -y
+apt-get -qq install libssl-dev -y
 #install pip
-curl https://bootstrap.pypa.io/get-pip.py | python
+curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python
 apt-get -qq install vlc -y
-apt-get -qq install php5-gd -y
-apt-get -qq install php5 -y
+apt-get -qq install php5.6-gd -y
+apt-get -qq install php5.6 -y
 apt-get -qq install gammu -y
 apt-get -qq install usb-modeswitch -y
 apt-get -qq install python-gammu -y


### PR DESCRIPTION
list of related dependencies
- `php` - currently used php5.6, need to add 3rd party repository for legacy version of php
- `opencv-python` - on latest version, python import header changed
- `pip` - python 2.7 need to specific version on download url cause it's no longer support
- `libssl`, `libffi` - used to build `telepot` and `pycrypto`